### PR TITLE
new: Rangarr v0.6.3 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-04-28
+
+### Fixed
+
+- Sorting and interleaving of Sonarr season pack searches are now handled correctly. Season pack items and individual episode items are sorted according to `search_order` and properly interleaved before being dispatched. (#52)
+
 ## [0.6.2] - 2026-04-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -28,8 +28,12 @@
 - **Smart Staggering:** Prevents "thundering herd" issues by spacing out search requests.
 - **Proportional Interleaving:** Balanced searching between missing items and upgrades.
 - **Weighted Distribution:** Prioritize specific instances (e.g., prioritize Movies over Music).
+- **Season Pack Support:** Group Sonarr searches by season, with automatic fallback to individual episode searches for seasons that are still airing.
 - **Retry Logic:** Intelligent skip windows for recently searched items, plus automatic startup connection retries (3 attempts, 10-second delay) to handle Docker Compose race conditions.
 - **Custom Format Score Awareness:** Finds Radarr and Sonarr items below their custom format score target — candidates *arr's Cutoff Unmet endpoint silently omits.
+- **Tag Filtering:** Restrict searches to items with specific *arr tags, or exclude tagged items entirely.
+- **Active Hours:** Restrict searches to a configured time window (e.g., overnight only) to avoid peak indexer load.
+- **Flexible Configuration:** Configure via `config.yaml` with `${ENV_VAR}` expansion for secrets, or skip the file entirely and use environment variables only.
 - **No External Connections:** Only communicates with the *arr instances you configure. No telemetry, no phone-home, no external services.
 
 ## Why Rangarr?

--- a/docs/technical-audit.md
+++ b/docs/technical-audit.md
@@ -45,7 +45,7 @@ To be absolutely clear, Rangarr does not and will never:
 
 ## Architecture Overview
 
-Rangarr is a ~1,311-line Python service with three core modules:
+Rangarr is a ~1,402-line Python service with three core modules:
 
 ```
 rangarr/
@@ -190,7 +190,7 @@ Rangarr operates entirely within your local network (or wherever you host your *
 
 ### 1. Security Through Simplicity
 
-**Decision:** ~1,311 lines of core Python code, zero external dependencies beyond requests and PyYAML.
+**Decision:** ~1,402 lines of core Python code, zero external dependencies beyond requests and PyYAML.
 
 **Why:** Small codebases are auditable. Every line of code is a potential attack surface. By keeping the codebase minimal, security reviewers can read and understand the entire project in under an hour.
 
@@ -217,7 +217,7 @@ Rangarr operates entirely within your local network (or wherever you host your *
 
 ### 4. Test Coverage as Documentation
 
-**Decision:** 250 tests covering all code paths, including error conditions.
+**Decision:** 287 tests covering all code paths, including error conditions.
 
 **Why:** Tests serve three purposes:
 1. Prevent regressions.
@@ -306,14 +306,23 @@ Every line of AI-generated code was reviewed, tested, and validated against requ
 
 ## Testing Strategy
 
-**Test Coverage:** See `tests/` directory.
+**Test Coverage:** See `rangarr/` and `tests/` directories.
 
+Unit tests (co-located with source):
 - `test_config_parser.py`: Configuration validation without network calls.
-- `test_arr_client.py`: Client logic with mocked HTTP responses.
-- `test_arr_client_sort.py`: Client-side sorting for all search orders across all client types.
-- `test_sonarr_season_packs.py`: Season pack search logic with mocked HTTP responses.
 - `test_env_config.py`: Environment variable configuration loading.
+- `test_validators.py`: Input validation logic.
 - `test_main.py`: Orchestration loop with mocked clients.
+- `clients/test_arr_base.py`: Shared ArrClient base class behaviour.
+- `clients/test_arr_client_sort.py`: Client-side sorting for all search orders across all client types.
+- `clients/test_radarr.py`, `clients/test_sonarr.py`, `clients/test_lidarr.py`: Client-specific logic with mocked HTTP responses.
+- `clients/test_sonarr_sort.py`: Sorting and interleaving correctness for Sonarr season pack results.
+
+Integration / system tests (`tests/`):
+- `integration/test_search_cycle.py`: Full search cycle with mocked *arr API responses.
+- `integration/test_sonarr_season_packs.py`: Season pack search logic end-to-end.
+- `integration/test_tag_filtering.py`: Tag-based include/exclude filtering.
+- `system/test_app_flow.py`: Full application flow smoke test.
 
 **Testing Without Production Instances:**
 
@@ -337,8 +346,8 @@ Both are widely-used, well-maintained libraries with public security disclosure 
 
 - `main.py`: ~329 lines
 - `config_parser.py`: ~361 lines
-- `clients/arr.py`: ~710 lines
-- **Total:** ~1,400 lines of Python (excluding tests/comments)
+- `clients/arr.py`: ~712 lines
+- **Total:** ~1,402 lines of Python (excluding tests/comments)
 
 The small codebase size makes comprehensive security auditing feasible.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rangarr"
-version = "0.6.2"
+version = "0.6.3"
 description = "Python-based orchestration service for *arr clients"
 requires-python = ">=3.13"
 dependencies = [


### PR DESCRIPTION
## Summary

- Bump version to `0.6.3`
- Add `[0.6.3]` CHANGELOG entry: season pack sorting/interleaving fix (#52)
- Update README Key Features (Season Packs, Tag Filtering, Active Hours, Flexible Configuration)
- Update `docs/technical-audit.md`: line counts, test count, and testing strategy file list