### PR TITLE
new: Rangarr v0.7.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-02
+
 ### Changed
 
 - **Global search slot allocation:** Rangarr now uses a centralized weighted round-robin "dealer" to distribute search slots across all active instances rather than processing each instance independently. The search cycle runs as a three-stage pipeline:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rangarr"
-version = "0.6.3"
+version = "0.7.0"
 description = "Python-based orchestration service for *arr clients"
 requires-python = ">=3.13"
 dependencies = [


### PR DESCRIPTION
Move [Unreleased] changes into v0.7.0 and bump version.