### PR TITLE
chg: Migrate CHANGELOG [Unreleased] to [0.9.0].

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-24
+
 ### Added
 
 - Readarr support. Add instances of type `readarr` to manage book libraries alongside existing Radarr, Sonarr, and Lidarr instances.


### PR DESCRIPTION
Migrates the CHANGELOG.md `[Unreleased]` section to `[0.9.0] - 2026-05-24` following the v0.9.0 release.