### PR TITLE
fix: Windows path separator compatibility in test_main.py

### DIFF
--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -563,7 +563,8 @@ def test_run(
     """Test run function loads config and executes searches."""
 
     def is_file_mock(path_obj: Any) -> Any:
-        return str(path_obj) == config_file_exists if config_file_exists else False
+        path_str = str(path_obj).replace('\\', '/')
+        return path_str == config_file_exists if config_file_exists else False
 
     run_client = MagicMock()
     run_client.name = 'Test'

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -563,8 +563,7 @@ def test_run(
     """Test run function loads config and executes searches."""
 
     def is_file_mock(path_obj: Any) -> Any:
-        path_str = str(path_obj).replace('\\', '/')
-        return path_str == config_file_exists if config_file_exists else False
+        return path_obj.as_posix() == config_file_exists if config_file_exists else False
 
     run_client = MagicMock()
     run_client.name = 'Test'


### PR DESCRIPTION
## Description
Test `test_run[loads_volume_config_first]` was failing on Windows because `pathlib.Path` converts forward slashes to backslashes on Windows. On Windows, `str(Path('config/config.yaml'))` returns `'config\\config.yaml'` with backslashes, but the test mock compared against forward slashes, causing a mismatch. 

This fix normalizes path separators to forward slashes for consistent cross-platform compatibility.

## Checklist
- [x] No sensitive data committed (API keys, passwords, real IPs)
- [x] Tests pass locally (pytest)
- [x] Linting passes (ruff, pylint, mypy, bandit)
- [x] Description of changes provided above
- [ ] Related issue number (if applicable): Pre-existing bug (no tracking issue)

## Related Issues
Pre-existing Windows compatibility issue discovered during testing.